### PR TITLE
Errors from second-order dispatch are swallowed

### DIFF
--- a/src/nexus/core.cljc
+++ b/src/nexus/core.cljc
@@ -165,7 +165,9 @@
                            (let [{:keys [effects errors]} (expand-actions nexus (:state ctx) (:actions ctx) (:dispatch-data ctx))
                                  !nested-errors (atom nil)
                                  dispatch!* (fn [& args]
-                                              (reset! !nested-errors (:errors (apply dispatch! args))))]
+                                              (let [res (apply dispatch! args)]
+                                                (reset! !nested-errors (:errors res))
+                                                (select-keys res [:results :errors])))]
                              (cond-> ctx
                                errors (assoc :errors errors)
                                effects (into (execute nexus (assoc (dissoc ctx :actions) :dispatch dispatch!*)

--- a/src/nexus/core.cljc
+++ b/src/nexus/core.cljc
@@ -162,13 +162,17 @@
           (let [handler {:phase :action-dispatch
                          :before-dispatch
                          (fn [ctx]
-                           (let [{:keys [effects errors]} (expand-actions nexus (:state ctx) (:actions ctx) (:dispatch-data ctx))]
+                           (let [{:keys [effects errors]} (expand-actions nexus (:state ctx) (:actions ctx) (:dispatch-data ctx))
+                                 !nested-errors (atom nil)
+                                 dispatch!* (fn [& args]
+                                              (reset! !nested-errors (:errors (apply dispatch! args))))]
                              (cond-> ctx
                                errors (assoc :errors errors)
-                               effects (into (execute nexus (assoc (dissoc ctx :actions) :dispatch dispatch!)
+                               effects (into (execute nexus (assoc (dissoc ctx :actions) :dispatch dispatch!*)
                                                       (cond->> effects
                                                         (not= actions effects)
-                                                        (interpolate nexus (:dispatch-data ctx))))))))}]
+                                                        (interpolate nexus (:dispatch-data ctx)))))
+                               @!nested-errors (update :errors into @!nested-errors))))}]
             (run-interceptors {:system system
                                :state (when-let [system->state (:nexus/system->state nexus)]
                                         (system->state system))

--- a/test/nexus/core_test.cljc
+++ b/test/nexus/core_test.cljc
@@ -440,7 +440,7 @@
                  (nexus/dispatch (atom nil) {} [[:effects/dispatch-fail]])
                  h/datafy-errors)
              expected-errors))
-      (is (= @provided-dispatch-res
+      (is (= (h/datafy-errors @provided-dispatch-res)
              expected-errors)
           "provided dispatch returns errors on the same format")))
 

--- a/test/nexus/core_test.cljc
+++ b/test/nexus/core_test.cljc
@@ -301,6 +301,7 @@
                (reduce (fn [s [p v]] (assoc-in s p v)) state path-vs))))}})
 
 (deftest execute-test
+
   (testing "Fails when there is no implementation"
     (is (= (-> (nexus/execute {} {:system (atom {})} [[:effects/save [:number] 3]])
                h/datafy-errors)
@@ -408,6 +409,35 @@
            {:results [{:effect [:effects/save [:number] 6]
                        :res {:step-size 3
                              :number 6}}]})))
+
+  (testing "Returns errors from effect"
+    (is (= (-> {:nexus/system->state deref
+                :nexus/effects
+                {:effects/fail
+                 (fn [_ _]
+                   (throw (ex-info "Boom!" {})))}}
+               (nexus/dispatch (atom nil) {} [[:effects/fail]])
+               h/datafy-errors)
+           {:errors [{:effect [:effects/fail]
+                      :err    {:data    {}
+                               :message "Boom!"}
+                      :phase  :execute-effect}]})))
+
+  (testing "Returns errors from effect that is dispatched from effect"
+    (is (= (-> {:nexus/system->state deref
+                :nexus/effects
+                {:effects/fail
+                 (fn [_ _]
+                   (throw (ex-info "Boom!" {})))
+                 :effects/dispatch-fail
+                 (fn [{:keys [dispatch]} _]
+                   (dispatch [[:effects/fail]]))}}
+               (nexus/dispatch (atom nil) {} [[:effects/dispatch-fail]])
+               h/datafy-errors)
+           {:errors [{:effect [:effects/fail]
+                      :err    {:data    {}
+                               :message "Boom!"}
+                      :phase  :execute-effect}]})))
 
   (testing "Runs interceptors in order"
     (is (= (let [store (atom {:step-size 3})

--- a/test/nexus/core_test.cljc
+++ b/test/nexus/core_test.cljc
@@ -301,7 +301,6 @@
                (reduce (fn [s [p v]] (assoc-in s p v)) state path-vs))))}})
 
 (deftest execute-test
-
   (testing "Fails when there is no implementation"
     (is (= (-> (nexus/execute {} {:system (atom {})} [[:effects/save [:number] 3]])
                h/datafy-errors)


### PR DESCRIPTION
When an effect dispatched from another effect via the provided `:dispatch` function throws, the error is swallowed rather than being caught and reported in the interceptor machinery.

This PR has two new tests for `nexus.core/dispatch`. The first one tests the simple case, where an error is thrown in an effect handler. This test passes.

The second test dispatches an effect from an effect handler using the passed-in `:dispatch` function. This second-order effect (for lack of a better term) throws. This error is not caught and returned.

Apologies for not providing the fix too! 😅 My hope is that you'll instantly see what's wrong and be able to fix it. Otherwise I'll give it a crack.