### PR TITLE
Track dispatch entries with stack to handle nested dispatch

### DIFF
--- a/src/nexus/action_log.cljc
+++ b/src/nexus/action_log.cljc
@@ -4,7 +4,8 @@
             [nexus.registry :as nxr]))
 
 (defn create-log []
-  (atom []))
+  (atom {:entries     []
+         :entry-stack []}))
 
 (defn install-logger [nexus log]
   (-> nexus
@@ -15,9 +16,9 @@
   (add-watch
    log ::inspect
    (fn [_ _ _ the-log]
-     (when (contains? (last the-log) :results)
+     (when (contains? (last (:entries the-log)) :results)
        (dataspex/inspect (or label "Actions")
-         (inspector/->LogInspector the-log)
+         (inspector/->LogInspector (:entries the-log))
          (cond-> {:track-changes? false}
            ns-aliases (assoc :ns-aliases ns-aliases)))))))
 

--- a/src/nexus/inspector.cljc
+++ b/src/nexus/inspector.cljc
@@ -48,49 +48,50 @@
 (defn get-detail-entries [{:keys [dispatched-at actions dispatch-data
                                   effects results expansions dom-event
                                   dispatch-elapsed state error errors]}]
-  (concat
-   [{:label (hiccup/string-label "Dispatched at")
-     :k :dispatched-at
-     :v dispatched-at}]
-   (when dom-event
-     [{:label (hiccup/string-label "DOM Event")
-       :k :dom-event
-       :v dom-event}])
-   (if (or (nil? effects) (= (:data effects) (:data actions)))
-     [{:label (hiccup/string-label "Actions")
-       :k :dispatched
-       :v actions}]
-     (->> [{:label (hiccup/string-label "Actions")
-            :k :dispatched
-            :v actions}
-           (when (seq effects)
-             {:label (hiccup/string-label "Effects")
-              :k :effects
-              :v effects})
-           {:label (hiccup/string-label "Expansions")
-            :k :expansions
-            :v expansions}]
-          (remove nil?)))
-   [{:label (hiccup/string-label "State")
-     :k :state
-     :v state}
-    {:label (hiccup/string-label "Dispatch data")
-     :k :dispatch-data
-     :v dispatch-data}]
-   (when error
-     [{:label (hiccup/string-label "Error")
-       :k :error
-       :v error}])
-   (when errors
-     [{:label (hiccup/string-label "Errors")
-       :k :errors
-       :v errors}])
-   [{:label (hiccup/string-label "Results")
-     :k :results
-     :v (keep :res results)}
-    {:label (hiccup/string-label "Dispatch time")
-     :k :dispatch-elapsed
-     :v (hiccup/string-label (str dispatch-elapsed "ms"))}]))
+  (let [effects-action (->actions effects)]
+    (concat
+     [{:label (hiccup/string-label "Dispatched at")
+       :k :dispatched-at
+       :v dispatched-at}]
+     (when dom-event
+       [{:label (hiccup/string-label "DOM Event")
+         :k :dom-event
+         :v dom-event}])
+     (if (or (nil? effects) (= (:data effects-action) (:data actions)))
+       [{:label (hiccup/string-label "Actions")
+         :k :dispatched
+         :v actions}]
+       (->> [{:label (hiccup/string-label "Actions")
+              :k :dispatched
+              :v actions}
+             (when (seq effects)
+               {:label (hiccup/string-label "Effects")
+                :k :effects
+                :v effects-action})
+             {:label (hiccup/string-label "Expansions")
+              :k :expansions
+              :v expansions}]
+            (remove nil?)))
+     [{:label (hiccup/string-label "State")
+       :k :state
+       :v state}
+      {:label (hiccup/string-label "Dispatch data")
+       :k :dispatch-data
+       :v dispatch-data}]
+     (when error
+       [{:label (hiccup/string-label "Error")
+         :k :error
+         :v error}])
+     (when errors
+       [{:label (hiccup/string-label "Errors")
+         :k :errors
+         :v errors}])
+     [{:label (hiccup/string-label "Results")
+       :k :results
+       :v (keep :res results)}
+      {:label (hiccup/string-label "Dispatch time")
+       :k :dispatch-elapsed
+       :v (hiccup/string-label (str dispatch-elapsed "ms"))}])))
 
 (deftype ActionDetails [details]
   dp/IRenderDictionary
@@ -156,9 +157,12 @@
 (defn round-tenth [ms]
   (/ (Math/round (* ms 10)) 10.0))
 
-(defn ^{:indent 1} update-current [log f & args]
-  (swap! log (fn [entries]
-               (apply update entries (dec (count entries)) f args))))
+(defn ^{:indent 1} update-entry [log idx f & args]
+  (swap! log (fn [state]
+               (apply update-in state [:entries idx] f args))))
+
+(defn current-entry-idx [log]
+  (peek (:entry-stack @log)))
 
 (def conjv (fnil conj []))
 (def intov (fnil into []))
@@ -175,12 +179,17 @@
                      nil)
                    (filter event?)
                    first)]
-    (swap! log conj (cond-> {:dispatched-at (now)
-                             :actions (->actions actions)
-                             :dispatch-data dispatch-data
-                             :dispatch-start (now-ms)
-                             :state state}
-                      event (assoc :dom-event event)))
+    (swap! log (fn [{:keys [entries] :as log-state}]
+                 (let [entry-idx (count entries)]
+                   (-> log-state
+                       (update :entries conj
+                               (cond-> {:dispatched-at (now)
+                                        :actions (->actions actions)
+                                        :dispatch-data dispatch-data
+                                        :dispatch-start (now-ms)
+                                        :state state}
+                                 event (assoc :dom-event event)))
+                       (update :entry-stack conj entry-idx)))))
     ctx))
 
 (defn ->error [error]
@@ -190,31 +199,34 @@
     (:effects error) (update :effects ->actions)))
 
 (defn after-dispatch [log ctx]
-  (update-current log
-    (fn [entry]
-      (cond-> (-> (update entry :effects ->actions)
-                  (assoc :dispatch-elapsed (round-tenth (- (now-ms) (:dispatch-start entry))))
-                  (dissoc :dispatch-start)
-                  (assoc :results (for [res (:results ctx)]
-                                    (cond-> res
-                                      (:effect res) (update :effect ->action)
-                                      (:effects res) (update :effects ->actions)))))
-        (= 1 (count (:errors ctx)))
-        (assoc :error (->error (first (:errors ctx))))
+  (let [entry-idx (current-entry-idx log)]
+    (swap! log update :entry-stack pop)
+    (update-entry log entry-idx
+      (fn [entry]
+        (cond-> (-> entry
+                    (assoc :dispatch-elapsed (round-tenth (- (now-ms) (:dispatch-start entry))))
+                    (dissoc :dispatch-start)
+                    (assoc :results (for [res (:results ctx)]
+                                      (cond-> res
+                                        (:effect res) (update :effect ->action)
+                                        (:effects res) (update :effects ->actions)))))
+          (= 1 (count (:errors ctx)))
+          (assoc :error (->error (first (:errors ctx))))
 
-        (< 1 (count (:errors ctx)))
-        (assoc :errors (map ->error (:errors ctx))))))
+          (< 1 (count (:errors ctx)))
+          (assoc :errors (map ->error (:errors ctx)))))))
   ctx)
 
 (defn after-action [log ctx]
-  (update-current log update :expansions conjv
-                  {:action (->action (or (:nexus/action (meta (:action ctx)))
-                                         (:action ctx)))
-                   :expansion (->actions (:actions ctx))})
+  (update-entry log (current-entry-idx log)
+    update :expansions conjv
+    {:action    (->action (or (:nexus/action (meta (:action ctx)))
+                              (:action ctx)))
+     :expansion (->actions (:actions ctx))})
   ctx)
 
 (defn before-effect [log ctx]
-  (update-current log
+  (update-entry log (current-entry-idx log)
     (fn [entry]
       (if (:effects ctx)
         (-> entry


### PR DESCRIPTION
OK, I'll just state this upfront: The code and tests in this PR is written mostly by Claude, under my instructions. The gods know I tried hard to understand the issue on my own to create a minimal repro of the error I was seeing in my app. In the end an hour with clojure-mcp and Claude Opus resulted in what you see here. I fully admit I haven't grasped how nexus.inspector work in detail. I guided the LLM to write the test case first, after it "understood" the actual error I was getting in the browser console.

Anyway, the problem I had was this: Some effect handlers were throwing exceptions in my app only when the inspector was installed. This is how I installed the inspector in dev:
```
(defn inspect-actions
  [nexus]
  (let [log (action-log/create-log)]
    (action-log/install-inspector log)
    (action-log/install-logger nexus log)))
```

The exception I got in the browser console:
```
util.cljc:47 Error in Nexus effect: [:effect.layers/back]
util.cljc:52 Uncaught Error: No item 1 in vector of length 1
    at Object.cljs$core$vector_index_out_of_bounds [as vector_index_out_of_bounds] (core.cljs:5528:10)
    at Object.cljs$core$array_for [as array_for] (core.cljs:5552:6)
    at Object.eval [as cljs$core$IIndexed$_nth$arity$2] (core.cljs:5726:12)
    at cljs$core$_nth.eval [as cljs$core$IFn$_invoke$arity$2] (core.cljs:613:10)
    at Object.cljs$core$_nth [as _nth] (core.cljs:611:1)
    at Object.eval [as cljs$core$ICollection$_conj$arity$2] (inspector.cljc:19:1)
    at Object.cljs$core$_conj [as _conj] (core.cljs:602:16)
    at cljs$core$conj.eval [as cljs$core$IFn$_invoke$arity$2] (core.cljs:1842:8)
    at G__52810.G__52810__2 [as cljs$core$IFn$_invoke$arity$2] (core.cljs:4441:14)
    at eval (core.cljs:5471:16)
[plus lots more]
```

The gist of it is this:
When an effect triggers a nested dispatch (e.g., via `(:dispatch ctx)`), subsequent effects from the original dispatch are logged to the wrong entry. This happens because `update-current` always updates `(dec (count log))`, which points to the nested dispatch's entry after it's created.

**Symptoms:**
- Effects with 2+ elements silently added as map entries to the nested dispatch's Action record
- Effects with 1 element throw IndexOutOfBoundsException (ClojureScript) or IllegalArgumentException (Clojure)

**The proposed fix:**
Track active dispatch entries using a stack. Push entry index on before-dispatch, pop on after-dispatch, and use the stack top to determine which entry to update.

## Final disclaimer and pre-emptive apology

If you want to close and disregard this PR on account of the LLM-provided code, I totally get it, because I don't really understand neither the problem nor the fix. My hope is that at least the failing test case can help you, who know the code intimately, understand the problem.

In that case, my apologies, and sorry for wasting your time! 😅

That being said, the code in this PR solves the problem in my app, so that's something.

If you're curious about the process behind the PR, this is the chat log: https://claude.ai/share/a2fb01f8-2e97-4531-8ac2-5d19652cb4cb