### PR TITLE
Reversed actions fix

### DIFF
--- a/src/nexus/core.cljc
+++ b/src/nexus/core.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.walk :as walk]))
 
 (def conjv (fnil conj []))
-(def intov (fnil into []))
+(defn intov [a b] (into (vec a) b))
 
 (defn assoc-some [m k v]
   (cond-> m
@@ -93,7 +93,7 @@
 
           :else
           (let [res (expand-action nexus state ctx (first actions))
-                remaining-actions (intov (next actions) (:actions res))]
+                remaining-actions (intov (:actions res) (next actions))]
             (cond-> res
               (seq remaining-actions) (assoc :actions remaining-actions)))))
       (-> (select-keys ctx [:errors :trace])

--- a/test/nexus/core_test.cljc
+++ b/test/nexus/core_test.cljc
@@ -236,7 +236,19 @@
             [:action]
             [:after-action 3 :actions/inc [:effects/save]]
             [:after-action 2 :actions/inc [:effects/save]]
-            [:after-action 1 :actions/inc [:effects/save]]]))))
+            [:after-action 1 :actions/inc [:effects/save]]])))
+
+
+  (testing "Preserves order of residual actions during recursive expansion"
+    ;; A repro / regression test for the bug addressed by https://github.com/cjohansen/nexus/pull/11
+    ;; When recursively expanding actions, action order was being reversed
+    (is (= (-> {:nexus/actions
+                {:actions/outer (fn [_] [[:actions/inner] [:effects/tail]])
+                 :actions/inner (fn [_] [[:effects/a] [:effects/b] [:effects/c]])}}
+               (nexus/expand-action {} {} [:actions/outer])
+               :actions
+               vec)
+           [[:effects/b] [:effects/c] [:effects/tail]]))))
 
 (deftest interpolate-test
   (testing "No-ops when there are no placeholders"


### PR DESCRIPTION
claude says:
When an action handler expands to [[inner] [tail]] and [inner] expands to                                                                                        
[a b c], expand-action emits residual :actions in the order [c b tail] --                                                                                       
inner's residual sub-actions arrive reversed, breaking the natural                                                                                     
"do A, then B" reading of a handler's return vector.                                                                                                   
 

cormac says:
Hey Christian - came across this earlier today while debugging a sequencing issue with our serial comms. The analysis / fix is entirely claude generated, but it's very localised / fairly unambiguous.

Otherwise this branch has been holding up pretty well for us.
