### PR TITLE
Don't clobber before-action interceptor additions to ctx

### DIFF
--- a/src/nexus/core.cljc
+++ b/src/nexus/core.cljc
@@ -103,7 +103,7 @@
              (let [actions (apply action-f (:state ctx*) (next (:action ctx*)))]
                (cond
                  (empty? actions)
-                 (reset-ctx-nesting ctx* ctx)
+                 (reset-ctx-nesting ctx (assoc ctx* :actions []))
 
                  (not (actions? actions))
                  (update ctx* :errors conjv

--- a/test/nexus/core_test.cljc
+++ b/test/nexus/core_test.cljc
@@ -154,6 +154,22 @@
                (nexus/dispatch (atom {}) {} [[:actions/test "it"]]))
            {})))
 
+  (testing "Preserves before-action context when action expands to nil"
+    (is (= (let [log (atom [])]
+             (-> test-nexus
+                 (assoc-in [:nexus/actions :actions/test] (constantly nil))
+                 (h/with-interceptor :before-action
+                   #(assoc % ::before-action-ran? true))
+                 (h/with-interceptor :after-action
+                   (fn [context]
+                     (swap! log conj (select-keys context [:action :actions ::before-action-ran?]))
+                     context))
+                 (nexus/dispatch (atom {}) {} [[:actions/test "it"]]))
+             @log)
+           [{:action [:actions/test "it"]
+             :actions []
+             ::before-action-ran? true}])))
+
   (testing "Returns error when action handler does not return collection of actions"
     (is (= (-> test-nexus
                (assoc-in


### PR DESCRIPTION
When an action expands to nil, nexus was resetting context, clobbering any keys added by before-action interceptors, which could result in later errors in after-action interceptors relying on those context additions.